### PR TITLE
add icon-social.svg redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -404,5 +404,6 @@
   "intellectual-property-rights-policy/thank-you": "http://www.ubuntu.com/legal/terms-and-policies/contact-us",
   "privacy-policy": "http://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
   "privacy-policy/": "http://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
-  "livepatch": "http://auth.livepatch.canonical.com"
+  "livepatch": "http://auth.livepatch.canonical.com",
+  "img/icons/icon-social.svg": "https://assets.ubuntu.com/v1/3a7c44e0-icon-social.svg"
 }


### PR DESCRIPTION
## Done

* fixes a Marketo bug as this file was removed, but still needed
* I updated the Marketo template so new files do not require this. 