### PR TITLE
update insights news link

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -506,8 +506,8 @@ google.maps.event.addDomListener(window, 'load', initialize);
         <h2>Further information</h2>
       </div>
     <div class="four-col">
-      <h3><a href="https://insights.ubuntu.com/topics/news/" class="further-news">News &rsaquo;</a></h3>
-      <div><ul class="no-bullets" id="news-feed"><noscript><li><a href="https://insights.ubuntu.com/topics/news/" title="go the Press centre on the Ubuntu insights" class="external">See all our Press centre on Ubuntu insights</a></li></noscript></ul></div>
+      <h3><a href="https://insights.ubuntu.com/press-centre/" class="further-news">News &rsaquo;</a></h3>
+      <div><ul class="no-bullets" id="news-feed"><noscript><li><a href="https://insights.ubuntu.com/press-centre/" title="go the Press centre on the Ubuntu insights" class="external">See all our Press centre on Ubuntu insights</a></li></noscript></ul></div>
     </div>
     <div class="four-col">
       <h3><a href="https://insights.ubuntu.com/" class="further-resources">Resources &rsaquo;</a></h3>


### PR DESCRIPTION
### Done

Corrected broken links on the /about page.

### QA
Got to `/about` and ensure that the "News ›" link near the bottom of the page doesn't 404.