### PR TITLE
Remove core.homeAnimation

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -193,15 +193,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     }
   };
 
-  core.homeAnimation = function() {
-    if(Y.one('body').hasClass('home')){
-      var anim = Y.one('.animation');
-      if(anim != null) {
-        anim.addClass('run');
-      }
-    }
-  };
-
   core.extendGlobalNav = function() {
     core.setupGlobalNav();
     if (navGlobal = Y.one('#nav-global')) {
@@ -229,7 +220,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
   core.setupHtmlClass();
   core.sectionTabs();
   core.tabbedContent();
-  core.homeAnimation();
   core.svgFallback();
   core.resizeListener();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
 		</div>
 		<div class="six-col last-col">
 			<img src="{{ ASSET_SERVER_URL }}15b74eb1-image-technology-for-innovators.png" class="static" alt="" />
-			<div class="animation">
+			<div class="animation run">
 				<img src="{{ ASSET_SERVER_URL }}7310840a-animation-text.png" alt="" class="text" />
 				<div class="dot-1"></div>
 				<div class="dot-2"></div>


### PR DESCRIPTION
As the first step to replacing all JavaScript that depends on YUI, I'm removing the homeAnimation function.

I don't understand why it's needed. All it seems to do is add the "run" class to the "animation" element,
which is the same as just including it in the markup in the first place.

I imagine I'm missing something, someone please enlighten me.

QA
--

Run the site (`make run`) and check the homepage animation still works.