### PR TITLE
Rewrite core.setupAccordion to remove YUI

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -76,4 +76,24 @@ core.setupTabs = function (menuAnchors, tabItems) {
       }(menuAnchors, tabItems)
     );
   });
+
+
+/**
+ * Given a DOM element containing an <a> and a <div>,
+ * Setup the <a> to toggle showing and hiding of the <div>
+ */
+core.setupAccordion = function(container) {
+  container.querySelector('h3').appendChild(document.createElement('span'));
+  toggleTarget = container.querySelector('div');
+  container.querySelector('a').addEventListener(
+    'click',
+    function (target) {
+      return function(clickEvent) {
+        clickEvent.preventDefault();
+        toggleAnchor = clickEvent.target.closest('a');
+        toggleAnchor.classList.toggle('active');
+        target.classList.toggle('active');
+      };
+    }(toggleTarget)
+  );
 };

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -79,17 +79,5 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     }
   }
 
-  core.setupAccordion = function() {
-    Y.all('.row-project li').each(function(node) {
-      node.one('h3').append('<span></span>');
-      node.one('a').on('click',function(e) {
-        e.preventDefault();
-        this.toggleClass('active');
-        this.next('div').toggleClass('active');
-      });
-    });
-  };
-
-  core.setupAccordion();
   core.resizeListener();
 });

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -8,207 +8,207 @@
 
 {% block content %}
 <div class="row row-hero">
-	<div class="inner-wrapper">
-    <div class="eight-col">
-    	<h1>Open source is what we do</h1>
-			<p class="intro six-col">We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.</p>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <h1>Open source is what we do</h1>
+            <p class="intro six-col">We believe in the power of open source software. As well as driving our own projects, we contribute staff, code and funding to many more.</p>
+        </div>
+        <div class="four-col last-col text-centered">
+            <img src="{{ ASSET_SERVER_URL }}b4438cf8-image-picto-projects-we-love-195.png" alt="" width="195" height="196" />
+        </div>
     </div>
-    <div class="four-col last-col text-centered">
-			<img src="{{ ASSET_SERVER_URL }}b4438cf8-image-picto-projects-we-love-195.png" alt="" width="195" height="196" />
-    </div>
-	</div>
 </div>
 
 <div class="row row-project">
-	<div class="inner-wrapper">
-    	<h2 class="twelve-col muted-heading">Some projects we care about</h2>
-    	<ul class="no-bullets three-col">
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}0fcb234f-image-project-ubuntu.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}41391002-image-project-ubuntu-icon.png" alt="" class="small" />
-					<h3>Ubuntu</h3>
-				</a>
-				<div>
-					<p>Ubuntu is one of the world’s biggest and most influential open source projects. With new features continually being developed, there is plenty of opportunity to get involved.</p>
-					<p><a href="http://community.ubuntu.com/contribute" class="external">Contribute</a></p>
-				</div>
-			</li>
+    <div class="inner-wrapper">
+        <h2 class="twelve-col muted-heading">Some projects we care about</h2>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}e528c9ac-image-project-mir.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}2fbd96a8-image-project-mir-icon.png" alt="" class="small" />
-					<h3 class="alt">Mir</h3>
-				</a>
-				<div>
-					<p>A cross-platform client interface needs a cross-platform graphics stack. Mir is the next generation display server used by Ubuntu for its mobile and desktop form factors.</p>
-					<p><a href="https://wiki.ubuntu.com/Mir" class="external">Learn more<span class="accessibility-aid"> about Mir</span></a></p>
-				</div>
-			</li>
+        <ul class="no-bullets three-col">
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}0fcb234f-image-project-ubuntu.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}41391002-image-project-ubuntu-icon.png" alt="" class="small" />
+                    <h3>Ubuntu</h3>
+                </a>
+                <div>
+                    <p>Ubuntu is one of the world’s biggest and most influential open source projects. With new features continually being developed, there is plenty of opportunity to get involved.</p>
+                    <p><a href="http://community.ubuntu.com/contribute" class="external">Contribute</a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}23d53e8b-maas-card.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}045fe3a2-maas-icon.png" alt="" class="small" />
-					<h3>MAAS</h3>
-				</a>
-				<div>
-					<p>Installing and deploying cloud computing at datacentre scale is often complicated and time consuming. Metal as a Service (MAAS) lets you treat physical servers like virtual machines in the cloud, turning  your bare metal into an elastic, cloud-like resource.</p>
-					<p><a href="http://maas.ubuntu.com" class="external">Learn more<span class="accessibility-aid"> about MAAS</span></a></p>
-				</div>
-			</li>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}e528c9ac-image-project-mir.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}2fbd96a8-image-project-mir-icon.png" alt="" class="small" />
+                    <h3 class="alt">Mir</h3>
+                </a>
+                <div>
+                    <p>A cross-platform client interface needs a cross-platform graphics stack. Mir is the next generation display server used by Ubuntu for its mobile and desktop form factors.</p>
+                    <p><a href="https://wiki.ubuntu.com/Mir" class="external">Learn more<span class="accessibility-aid"> about Mir</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}32c9eba3-image-project-upstart.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}6051979e-image-project-upstart-icon.png" alt="" class="small" />
-					<h3>Upstart</h3>
-				</a>
-				<div>
-					<p>Upstart is an event-based system that initialises services during boot, supervising them while the machine is running and stopping them during shutdown.</p>
-					<p><a href="http://upstart.ubuntu.com" class="external">Learn more<span class="accessibility-aid"> about Upstart</span></a></p>
-				</div>
-			</li>
-	    </ul>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}23d53e8b-maas-card.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}045fe3a2-maas-icon.png" alt="" class="small" />
+                    <h3>MAAS</h3>
+                </a>
+                <div>
+                    <p>Installing and deploying cloud computing at datacentre scale is often complicated and time consuming. Metal as a Service (MAAS) lets you treat physical servers like virtual machines in the cloud, turning  your bare metal into an elastic, cloud-like resource.</p>
+                    <p><a href="http://maas.ubuntu.com" class="external">Learn more<span class="accessibility-aid"> about MAAS</span></a></p>
+                </div>
+            </li>
 
-	    <ul class="no-bullets three-col">
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}802a1974-image-project-juju.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}a6123e46-image-project-juju-icon.png" alt="" class="small" />
-					<h3>Juju</h3>
-				</a>
-				<div>
-					<p>Deploying services into cloud and hyperscale environments used to be complex, error-prone and time-consuming - until now. Juju is the Ubuntu project’s service orchestration tool, which simplifies the installation and management of cloud applications.</p>
-					<p><a href="https://jujucharms.com/about" class="external">Learn more<span class="accessibility-aid"> about Juju</span></a></p>
-				</div>
-			</li>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}32c9eba3-image-project-upstart.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}6051979e-image-project-upstart-icon.png" alt="" class="small" />
+                    <h3>Upstart</h3>
+                </a>
+                <div>
+                    <p>Upstart is an event-based system that initialises services during boot, supervising them while the machine is running and stopping them during shutdown.</p>
+                    <p><a href="http://upstart.ubuntu.com" class="external">Learn more<span class="accessibility-aid"> about Upstart</span></a></p>
+                </div>
+            </li>
+        </ul>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}deb63474-image-project-open-input-framework.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}fa9f05f4-image-project-open-input-framework-icon.png" alt="" class="small" />
-					<h3 class="smaller">Open Input&nbsp;Framework</h3>
-				</a>
-				<div>
-					<p>The Open Input Framework (OIF) is a software stack that provides platform-agnostic multi-touch and gestural input for applications. Developers can use OIF directly or through a GUI toolkit.</p>
-					<p><a href="https://launchpad.net/canonical-multitouch" class="external">Learn more<span class="accessibility-aid"> about OIF</span></a></p>
-				</div>
-			</li>
+        <ul class="no-bullets three-col">
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}802a1974-image-project-juju.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}a6123e46-image-project-juju-icon.png" alt="" class="small" />
+                    <h3>Juju</h3>
+                </a>
+                <div>
+                    <p>Deploying services into cloud and hyperscale environments used to be complex, error-prone and time-consuming - until now. Juju is the Ubuntu project’s service orchestration tool, which simplifies the installation and management of cloud applications.</p>
+                    <p><a href="https://jujucharms.com/about" class="external">Learn more<span class="accessibility-aid"> about Juju</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}087d7bb9-image-project-bazaar.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}bceba197-image-project-bazaar-icon.png" alt="" class="small" />
-					<h3>Bazaar</h3>
-				</a>
-				<div>
-					<p>Collaborative software development can be complicated, especially when it comes to version control. Bazaar is a user-friendly, cross-platform Distributed Version Control System (DVCS) that runs on Windows, Mac OS X and  Linux.</p>
-					<p><a href="http://bazaar.canonical.com" class="external">Learn more<span class="accessibility-aid"> about Bazaar</span></a></p>
-				</div>
-			</li>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}deb63474-image-project-open-input-framework.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}fa9f05f4-image-project-open-input-framework-icon.png" alt="" class="small" />
+                    <h3 class="smaller">Open Input&nbsp;Framework</h3>
+                </a>
+                <div>
+                    <p>The Open Input Framework (OIF) is a software stack that provides platform-agnostic multi-touch and gestural input for applications. Developers can use OIF directly or through a GUI toolkit.</p>
+                    <p><a href="https://launchpad.net/canonical-multitouch" class="external">Learn more<span class="accessibility-aid"> about OIF</span></a></p>
+                </div>
+            </li>
 
-	    </ul>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}087d7bb9-image-project-bazaar.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}bceba197-image-project-bazaar-icon.png" alt="" class="small" />
+                    <h3>Bazaar</h3>
+                </a>
+                <div>
+                    <p>Collaborative software development can be complicated, especially when it comes to version control. Bazaar is a user-friendly, cross-platform Distributed Version Control System (DVCS) that runs on Windows, Mac OS X and  Linux.</p>
+                    <p><a href="http://bazaar.canonical.com" class="external">Learn more<span class="accessibility-aid"> about Bazaar</span></a></p>
+                </div>
+            </li>
+        </ul>
 
-	    <ul class="no-bullets three-col">
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}95abe343-image-project-openstack.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}f15a32ff-image-project-openstack-icon.png" alt="" class="small" />
-					<h3>OpenStack</h3>
-				</a>
-				<div>
-					<p>Cloud computing needed an open source, enterprise-scale infrastructure platform. Thanks to the work of Canonical and many other contributors, we have OpenStack.</p>
-					<p><a href="http://www.ubuntu.com/cloud" class="external">Learn more<span class="accessibility-aid"> about OpenStack</span></a></p>
-				</div>
-			</li>
+        <ul class="no-bullets three-col">
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}95abe343-image-project-openstack.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}f15a32ff-image-project-openstack-icon.png" alt="" class="small" />
+                    <h3>OpenStack</h3>
+                </a>
+                <div>
+                    <p>Cloud computing needed an open source, enterprise-scale infrastructure platform. Thanks to the work of Canonical and many other contributors, we have OpenStack.</p>
+                    <p><a href="http://www.ubuntu.com/cloud" class="external">Learn more<span class="accessibility-aid"> about OpenStack</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}cb908513-image-project-ubuntu-sdk.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}b7603fb6-image-project-ubuntu-sdk-icon.png" alt="" class="small" />
-					<h3>Ubuntu App SDK</h3>
-				</a>
-				<div>
-					<p>Ubuntu runs on all kinds of client devices, including tablets, phones and PCs. The Ubuntu App SDK comprises the developer tools and APIs needed to develop Ubuntu apps for any form factor.</p>
-					<p><a href="http://developer.ubuntu.com/apps/" class="external">Learn more<span class="accessibility-aid"> about the App SDK</span></a></p>
-				</div>
-			</li>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}cb908513-image-project-ubuntu-sdk.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}b7603fb6-image-project-ubuntu-sdk-icon.png" alt="" class="small" />
+                    <h3>Ubuntu App SDK</h3>
+                </a>
+                <div>
+                    <p>Ubuntu runs on all kinds of client devices, including tablets, phones and PCs. The Ubuntu App SDK comprises the developer tools and APIs needed to develop Ubuntu apps for any form factor.</p>
+                    <p><a href="http://developer.ubuntu.com/apps/" class="external">Learn more<span class="accessibility-aid"> about the App SDK</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}663faf72-image-project-launchpad.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}859c6932-image-project-launchpad-icon.png" alt="" class="small" />
-					<h3>Launchpad</h3>
-				</a>
-				<div>
-					<p>Launchpad enables developers to track and manage open source projects. Its features include code hosting, bug tracking and translation. Ubuntu is one of many projects that use Launchpad.</p>
-					<p><a href="http://www.launchpad.net" class="external">Learn more<span class="accessibility-aid"> about Launchpad</span></a></p>
-				</div>
-			</li>
-	    </ul>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}663faf72-image-project-launchpad.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}859c6932-image-project-launchpad-icon.png" alt="" class="small" />
+                    <h3>Launchpad</h3>
+                </a>
+                <div>
+                    <p>Launchpad enables developers to track and manage open source projects. Its features include code hosting, bug tracking and translation. Ubuntu is one of many projects that use Launchpad.</p>
+                    <p><a href="http://www.launchpad.net" class="external">Learn more<span class="accessibility-aid"> about Launchpad</span></a></p>
+                </div>
+            </li>
+        </ul>
 
-	    <ul class="no-bullets three-col last-col">
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}3800f898-image-project-debian.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}6d147b79-image-project-debian-icon.png" alt="" class="small" />
-					<h3>Debian</h3>
-				</a>
-				<div>
-					<p>Debian is one of the world’s largest free software communities, famed for its philosophy of collaborative development.  A firmly established Linux distribution, it shares much of its underlying architecture with Ubuntu.</p>
-					<p><a href="http://www.ubuntu.com/about/about-ubuntu/ubuntu-and-debian" class="external">Learn more<span class="accessibility-aid"> about Debian</span></a></p>
-				</div>
-			</li>
+        <ul class="no-bullets three-col last-col">
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}3800f898-image-project-debian.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}6d147b79-image-project-debian-icon.png" alt="" class="small" />
+                    <h3>Debian</h3>
+                </a>
+                <div>
+                    <p>Debian is one of the world’s largest free software communities, famed for its philosophy of collaborative development.  A firmly established Linux distribution, it shares much of its underlying architecture with Ubuntu.</p>
+                    <p><a href="http://www.ubuntu.com/about/about-ubuntu/ubuntu-and-debian" class="external">Learn more<span class="accessibility-aid"> about Debian</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}5e1a7707-image-project-cloud-init.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}7c35a9b6-image-project-cloud-init-icon.png" alt="" class="small" />
-					<h3>Cloud-init</h3>
-				</a>
-				<div>
-					<p>In cloud environments, image-sprawl can quickly become a problem. Cloud-init is a system initialisation program that imports data from the provider (e.g. Amazon EC2 or Microsoft Azure) which can be used to configure new images with greater control.</p>
-					<p><a href="http://cloudinit.readthedocs.org/en/latest/" class="external">Learn more<span class="accessibility-aid"> about Cloud-init</span></a></p>
-				</div>
-			</li>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}5e1a7707-image-project-cloud-init.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}7c35a9b6-image-project-cloud-init-icon.png" alt="" class="small" />
+                    <h3>Cloud-init</h3>
+                </a>
+                <div>
+                    <p>In cloud environments, image-sprawl can quickly become a problem. Cloud-init is a system initialisation program that imports data from the provider (e.g. Amazon EC2 or Microsoft Azure) which can be used to configure new images with greater control.</p>
+                    <p><a href="http://cloudinit.readthedocs.org/en/latest/" class="external">Learn more<span class="accessibility-aid"> about Cloud-init</span></a></p>
+                </div>
+            </li>
 
-			<li>
-				<a href="">
-					<img src="{{ ASSET_SERVER_URL }}d7606e81-image-project-unity.png" alt="" class="large" />
-					<img src="{{ ASSET_SERVER_URL }}6ac04b3b-image-project-unity-icon.png" alt="" class="small" />
-					<h3>Unity</h3>
-				</a>
-				<div>
-					<p>Unity is Ubuntu’s graphical user interface (GUI). Together with Mir, the new open source graphics stack, Unity makes Ubuntu easy to use  on a wide range of devices.</p>
-					<p><a href="https://unity.ubuntu.com/" class="external">Learn more<span class="accessibility-aid"> about Unity</span></a></p>
-				</div>
-			</li>
-		</ul>
-	</div>
+            <li>
+                <a href="">
+                    <img src="{{ ASSET_SERVER_URL }}d7606e81-image-project-unity.png" alt="" class="large" />
+                    <img src="{{ ASSET_SERVER_URL }}6ac04b3b-image-project-unity-icon.png" alt="" class="small" />
+                    <h3>Unity</h3>
+                </a>
+                <div>
+                    <p>Unity is Ubuntu’s graphical user interface (GUI). Together with Mir, the new open source graphics stack, Unity makes Ubuntu easy to use  on a wide range of devices.</p>
+                    <p><a href="https://unity.ubuntu.com/" class="external">Learn more<span class="accessibility-aid"> about Unity</span></a></p>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>
 
 <div class="row row-contextual-footer">
-			<div class="inner-wrapper vertical-divider">
-		    <div class="six-col featured">
-		        <h3><a href="/projects/directory">View Canonical project directory &rsaquo;</a></h3>
-		        <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
-		    </div>
-		    <div class="three-col">
-		        <h3><a class="external" href="http://www.ubuntu.com">Explore ubuntu.com</a></h3>
-		        <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs.  </p>
-		    </div>
-		    <div class="three-col last-col">
-		        <h3><a href="/services/contact-us">Contact us today &rsaquo;</a></h3>
-		        <p>Interested in Ubuntu Advantage? Talk to us today for more information.</p>
-		    </div>
-		  </div>
-		</div>
+    <div class="inner-wrapper vertical-divider">
+        <div class="six-col featured">
+            <h3><a href="/projects/directory">View Canonical project directory &rsaquo;</a></h3>
+            <p>See an overview of open source projects set up by Canonical, with contact information for each project.</p>
+        </div>
+        <div class="three-col">
+            <h3><a class="external" href="http://www.ubuntu.com">Explore ubuntu.com</a></h3>
+            <p>On ubuntu.com, you&rsquo;ll find out more about the platform, our management services and our partner programs.  </p>
+        </div>
+        <div class="three-col last-col">
+            <h3><a href="/services/contact-us">Contact us today &rsaquo;</a></h3>
+            <p>Interested in Ubuntu Advantage? Talk to us today for more information.</p>
+        </div>
+    </div>
+</div>
 {% endblock content %}
 
 {% block footer_extra %}
 <script>
-	document.querySelectorAll('.row-project li').forEach(core.setupAccordion);
+  document.querySelectorAll('.row-project li').forEach(core.setupAccordion);
 </script>
 {% endblock %}

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -206,3 +206,9 @@
 		  </div>
 		</div>
 {% endblock content %}
+
+{% block footer_extra %}
+<script>
+	document.querySelectorAll('.row-project li').forEach(core.setupAccordion);
+</script>
+{% endblock %}


### PR DESCRIPTION
**Please review & merge #105 first**

- Create `core.js` (following the www.ubuntu.com pattern), to house new JavaScript and eventually decommission `scratch.js`
- Add polyfills for new plain ES^ JavaScript work
- Rewrite `core.setupAccordion` and move it to `core.js`
- For clarity, call `core.setupAccordion` from `projects/index.html` rather than calling it when the JavaScript file is loaded

QA
---

```
make run
```

Visit <http://127.0.0.1:8002/projects> and check all product descriptions expand and collapse as expected.