### PR TITLE
Remove yui: basis

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -1,0 +1,9 @@
+/* Setup namespace
+ * TODO: Uncomment this once all core.* items have been removed from scratch.js
+ */
+
+// if (typeof core !== 'undefined') {
+//   throw TypeError("Namespace 'core' not available");
+// }
+
+// var core = {};

--- a/static/js/polyfills.js
+++ b/static/js/polyfills.js
@@ -1,0 +1,52 @@
+/* Polyfill functions
+ * =================== */
+
+/**
+ * Array.prototype.forEach polyfill
+ * from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+ */
+if (!Array.prototype.forEach) {
+    Array.prototype.forEach = function(fun) {
+        if (
+            this === void 0
+            || this === null
+            || typeof fun !== "function"
+        ) { throw new TypeError(); }
+
+        var t = Object(this);
+        var len = t.length >>> 0;
+
+        var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+        for (var i = 0; i < len; i++) {
+            if (i in t) {
+                fun.call(thisArg, t[i], i, t);
+            }
+        }
+    };
+}
+
+/**
+ * Add Array methods to NodeList
+ */
+Object.getOwnPropertyNames(Array.prototype).forEach(
+  function (methodName) {
+    if(!(methodName in NodeList.prototype)) {
+      NodeList.prototype[methodName] = Array.prototype[methodName];
+    }
+  }
+);
+
+/* Element.prototype.classList polyfill, by Eli Grey, http://eligrey.com
+ * https://github.com/eligrey/classList.js */
+if("document"in self){if(!("classList"in document.createElement("_"))||document.createElementNS&&!("classList"in document.createElementNS("http://www.w3.org/2000/svg","g"))){(function(t){"use strict";if(!("Element"in t))return;var e="classList",i="prototype",n=t.Element[i],s=Object,r=String[i].trim||function(){return this.replace(/^\s+|\s+$/g,"")},a=Array[i].indexOf||function(t){var e=0,i=this.length;for(;e<i;e++){if(e in this&&this[e]===t){return e}}return-1},o=function(t,e){this.name=t;this.code=DOMException[t];this.message=e},l=function(t,e){if(e===""){throw new o("SYNTAX_ERR","An invalid or illegal string was specified")}if(/\s/.test(e)){throw new o("INVALID_CHARACTER_ERR","String contains an invalid character")}return a.call(t,e)},c=function(t){var e=r.call(t.getAttribute("class")||""),i=e?e.split(/\s+/):[],n=0,s=i.length;for(;n<s;n++){this.push(i[n])}this._updateClassName=function(){t.setAttribute("class",this.toString())}},u=c[i]=[],f=function(){return new c(this)};o[i]=Error[i];u.item=function(t){return this[t]||null};u.contains=function(t){t+="";return l(this,t)!==-1};u.add=function(){var t=arguments,e=0,i=t.length,n,s=false;do{n=t[e]+"";if(l(this,n)===-1){this.push(n);s=true}}while(++e<i);if(s){this._updateClassName()}};u.remove=function(){var t=arguments,e=0,i=t.length,n,s=false,r;do{n=t[e]+"";r=l(this,n);while(r!==-1){this.splice(r,1);s=true;r=l(this,n)}}while(++e<i);if(s){this._updateClassName()}};u.toggle=function(t,e){t+="";var i=this.contains(t),n=i?e!==true&&"remove":e!==false&&"add";if(n){this[n](t)}if(e===true||e===false){return e}else{return!i}};u.toString=function(){return this.join(" ")};if(s.defineProperty){var h={get:f,enumerable:true,configurable:true};try{s.defineProperty(n,e,h)}catch(d){if(d.number===-2146823252){h.enumerable=false;s.defineProperty(n,e,h)}}}else if(s[i].__defineGetter__){n.__defineGetter__(e,f)}})(self)}else{(function(){"use strict";var t=document.createElement("_");t.classList.add("c1","c2");if(!t.classList.contains("c2")){var e=function(t){var e=DOMTokenList.prototype[t];DOMTokenList.prototype[t]=function(t){var i,n=arguments.length;for(i=0;i<n;i++){t=arguments[i];e.call(this,t)}}};e("add");e("remove")}t.classList.toggle("c3",false);if(t.classList.contains("c3")){var i=DOMTokenList.prototype.toggle;DOMTokenList.prototype.toggle=function(t,e){if(1 in arguments&&!this.contains(t)===!e){return e}else{return i.call(this,t)}}}t=null})()}}
+
+/* Element.prototype.addEventListener (https://gist.github.com/jonathantneal/3748027) */
+!window.addEventListener&&function(e,t,n,r,i,s,o){e[r]=t[r]=n[r]=function(e,t){var n=this;o.unshift([n,e,t,function(e){e.currentTarget=n,e.preventDefault=function(){e.returnValue=!1},e.stopPropagation=function(){e.cancelBubble=!0},e.target=e.srcElement||n,t.call(n,e)}]),this.attachEvent("on"+e,o[0][3])},e[i]=t[i]=n[i]=function(e,t){for(var n=0,r;r=o[n];++n)if(r[0]==this&&r[1]==e&&r[2]==t)return this.detachEvent("on"+e,o.splice(n,1)[0][3])},e[s]=t[s]=n[s]=function(e){return this.fireEvent("on"+e.type,e)}}(Window.prototype,HTMLDocument.prototype,Element.prototype,"addEventListener","removeEventListener","dispatchEvent",[])
+
+/* String.prototype.startsWith polyfill, by Mathius Bynens, https://mathiasbynens.be/
+ * https://github.com/mathiasbynens/String.prototype.startsWith */
+String.prototype.startsWith||!function(){"use strict";var t=function(){try{var t={},r=Object.defineProperty,e=r(t,t,t)&&r}catch(n){}return e}(),r={}.toString,e=function(t){if(null==this)throw TypeError();var e=String(this);if(t&&"[object RegExp]"==r.call(t))throw TypeError();var n=e.length,i=String(t),a=i.length,o=arguments.length>1?arguments[1]:void 0,h=o?Number(o):0;h!=h&&(h=0);var u=Math.min(Math.max(h,0),n);if(a+u>n)return!1;for(var g=-1;++g<a;)if(e.charCodeAt(u+g)!=i.charCodeAt(g))return!1;return!0};t?t(String.prototype,"startsWith",{value:e,configurable:!0,writable:!0}):String.prototype.startsWith=e}();
+
+/* Element.prototype.closest | CC0-1.0 | github.com/jonathantneal/closest
+ * https://github.com/jonathantneal/closest/ */
+!function(a){"function"!=typeof a.matches&&(a.matches=a.msMatchesSelector||a.mozMatchesSelector||a.webkitMatchesSelector||function(b){for(var c=this,d=(c.document||c.ownerDocument).querySelectorAll(b),e=0;d[e]&&d[e]!==c;)++e;return Boolean(d[e])}),"function"!=typeof a.closest&&(a.closest=function(b){for(var c=this;c&&1===c.nodeType;){if(c.matches(b))return c;c=c.parentNode}return null})}(window.Element.prototype);

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -114,6 +114,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script src="{{ ASSET_SERVER_URL }}94052790-global.js"></script>
 <script src="{{ STATIC_URL }}js/scratch.js"></script>
 <script src="{{ STATIC_URL }}js/polyfills.js"></script>
+<script src="{{ STATIC_URL }}js/core.js"></script>
 <!--<![endif]-->
 
 {% block footer_extra %}{% endblock %}

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -113,6 +113,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!--[if gte IE 9]><!-->
 <script src="{{ ASSET_SERVER_URL }}94052790-global.js"></script>
 <script src="{{ STATIC_URL }}js/scratch.js"></script>
+<script src="{{ STATIC_URL }}js/polyfills.js"></script>
 <!--<![endif]-->
 
 {% block footer_extra %}{% endblock %}


### PR DESCRIPTION
As a basis for starting the work of rewriting all JavaScript the depends on YUI, I am:

- Creating a new `core.js` file to house new core site JavaScript (following the pattern of www.ubuntu.com)
- I'll migrate the existing functions into `core.js` as they're rewritten to remove YUI
- Add polyfills to support development in plain JavaScript, allowing us to use modern methods with backards compatability (like www.ubuntu.com)

I will now propose 1 pull-request per JavaScript function that I re-write, but I will base them all off this one, which provides the basic infrastructure.

QA
---

Run the site (`make run`) and check nothing has changed.
