### PR TITLE
Rewrite core.cookiePolicy to remove YUI

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -7,3 +7,39 @@
 // }
 
 // var core = {};
+
+/**
+ * Show the cookie notification at the bottom of the page,
+ * unless it has previously been dismissed
+ */
+core.cookiePolicy = function() {
+  function createCookieNotification() {
+    // Create notification element
+    closeButton = utilities.createElementFromHtml('<button class="link-cta"></button>');
+    closeButton.addEventListener('click', acceptCookiePolicy); // On click, accept and hide
+
+    notification = utilities.createElementFromHtml('<div class="cookie-policy"><div class="wrapper"></div></div>');
+    wrapper = notification.querySelector('.wrapper');
+    wrapper.appendChild(closeButton);
+    wrapper.appendChild(
+      utilities.createElementFromHtml(
+        '<p>We use cookies to improve your experience. By your continued use of this site you accept such use. To change your settings please <a href="/privacy-policy#cookies">see our policy</a>.</p>'
+      )
+    );
+
+    // Add notification banner to bottom of body
+    document.body.appendChild(notification);
+  }
+
+  function acceptCookiePolicy(clickEvent) {
+    window.localStorage.setItem('cookiePolicyAccepted', 'true');
+    document.body.removeChild(clickEvent.target.closest('.cookie-policy'));
+  }
+
+  // If you don't have localStorage, you get away without having to see the cookie notification
+  if (window.localStorage) {
+    if(! JSON.parse(window.localStorage.getItem('cookiePolicyAccepted'))) {
+      createCookieNotification();
+    }
+  }
+};

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -19,26 +19,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     });
   };
 
-  core.cookiePolicy = function() {
-    function open() {
-      Y.one('body').prepend('<div class="cookie-policy"><div class="wrapper"><a href="?cp=close" class="link-cta">Close</a><p>We use cookies to improve your experience. By your continued use of this site you accept such use. To change your settings please <a href="/privacy-policy#cookies">see our policy</a>.</p></div></div>');
-      Y.one('.cookie-policy .link-cta').on('click',function(e){
-        e.preventDefault();
-        close();
-      });
-    }
-    function close() {
-      Y.one('.cookie-policy').setStyle('display','none');
-      setCookie();
-    }
-    function setCookie() {
-      Y.Cookie.set("_cookies_accepted", "true", { expires: new Date("January 12, 2025") });
-    }
-    if(Y.Cookie.get("_cookies_accepted") != 'true'){
-      open();
-    }
-  };
-
   core.tabbedContent = function() {
     Y.all('.tabbed-content .accordion-button').on('click', function(e){
       e.preventDefault();
@@ -175,7 +155,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
   };
 
   core.setupAccordion();
-  core.cookiePolicy();
   core.sectionTabs();
   core.tabbedContent();
   core.resizeListener();

--- a/static/js/utilities.js
+++ b/static/js/utilities.js
@@ -1,0 +1,17 @@
+/* Setup namespace
+ */
+
+if (typeof utilities !== 'undefined') {
+  throw TypeError("Namespace 'utilities' not available");
+}
+
+var utilities = {};
+
+/**
+ * Convert an HTML string into a tree of DOM elements
+ */
+utilities.createElementFromHtml = function(html) {
+  var div = document.createElement('div');
+  div.innerHTML = html;
+  return div.childNodes[0];
+};

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -114,6 +114,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script src="{{ ASSET_SERVER_URL }}94052790-global.js"></script>
 <script src="{{ STATIC_URL }}js/scratch.js"></script>
 <script src="{{ STATIC_URL }}js/polyfills.js"></script>
+<script src="{{ STATIC_URL }}js/utilities.js"></script>
 <script src="{{ STATIC_URL }}js/core.js"></script>
 <!--<![endif]-->
 

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -118,6 +118,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script src="{{ STATIC_URL }}js/core.js"></script>
 <!--<![endif]-->
 
+<script>
+  // Every page should show the cookie policy until accepted
+  core.cookiePolicy();
+</script>
+
 {% block footer_extra %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
**Please review & merge #105 first**

- Use plain JS
- USe localStorage over cookies
- Move to `core.js`

QA
---

```
make run
```

Go to <http://127.0.0.1:8002/> (or any other page) and check you see the cookie notification. Click the cross, check it goes away.
Reload the page or browse around the site, check it's still gone.

To reset back to check again, you need to remove the `cookiePolicyAccepted` key from localStorage. In chrome developer tools, do this under:

`Application -> Local Storage -> http://127.0.0.1:8002 -> {right click on cookiePolicyAccepted} -> delete`