### PR TITLE
Remove core.setupHtmlClass

### DIFF
--- a/static/css/section/_about.scss
+++ b/static/css/section/_about.scss
@@ -137,7 +137,7 @@ html.no-svg body.about-home {
 	}
 }
 
-html.yes-js body.about-home {
+html.js body.about-home {
 
 	.map-shadow-top,
 	.map-shadow-bottom {
@@ -255,7 +255,7 @@ html.yes-js body.about-home {
 		}
 	}
 
-	html.yes-js body.about-home {
+	html.js body.about-home {
 		.the-map {
 			display: block;
 			position: relative;
@@ -353,7 +353,7 @@ html.yes-js body.about-home {
 
 	}
 
-	html.yes-js body.about-home {
+	html.js body.about-home {
 		#map-canvas {
 			height: 460px;
 		}

--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -849,12 +849,6 @@ html.no-svg {
       background-image: url('https://assets.ubuntu.com/v1/48002a8b-external-link.png');
     }
   }
-  #additional-info h2.active span {
-    background-image: url("https://assets.ubuntu.com/v1/43e2b367-arrow_up_9fa097.png");
-  }
-  #additional-info h2 span {
-    background-image: url("https://assets.ubuntu.com/v1/7a7e0d52-arrow_down_9fa097.png");
-  }
 }
 
 /* Medium / Tablet viewport
@@ -937,36 +931,6 @@ html.no-svg {
       display: inline-block;
       min-height: 0;
     }
-  }
-
-  .yes-js #additional-info {
-    margin-bottom: 0;
-    margin-right: 0;
-    min-height: inherit;
-    padding: 0;
-    width: 18%;
-    float: right;
-  }
-
-  .yes-js #additional-info div {
-    display: block;
-    height: auto;
-  }
-
-  .yes-js #additional-info h2 {
-    border: 0;
-    margin: inherit;
-    padding: inherit;
-    padding-bottom: .75em;
-    float: left;
-    margin-left: 0;
-    display: block;
-    width: 100%;
-    clear: both;
-  }
-
-  .yes-js #additional-info h2 span {
-    display: none;
   }
 
   .pull-quote {

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -168,7 +168,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     } else if (document.documentElement.clientWidth >= 768) {
       core.globalPrepend = 'body';
       core.extendGlobalNav();
-      Y.all('#additional-info h2').setStyle('cursor', 'default');
     }
   };
 
@@ -188,7 +187,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
       if (globalNav) {
         globalNav.remove();
         core.extendGlobalNav();
-        Y.all('#additional-info h2').setStyle('cursor', 'default');
       }
     }
   };

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -12,11 +12,6 @@ String.prototype.format = function() {
 };
 
 YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', function(Y) {
-
-  core.setupHtmlClass = function() {
-    Y.one('html').removeClass('no-js').addClass('yes-js');
-  }
-
   core.setupAdditionalInfo = function() {
     Y.one('.find-out-more').setStyle('cursor', 'pointer').on('click',function(e) {
         this.toggleClass('active');
@@ -215,7 +210,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
 
   core.setupAccordion();
   core.cookiePolicy();
-  core.setupHtmlClass();
   core.sectionTabs();
   core.tabbedContent();
   core.svgFallback();


### PR DESCRIPTION
This function was only setting the `html.yes-js` class, which is redundant since Modernizr sets `.js`.

QA
---

Run the site (`make run`), and check, first with JavaScript that:

- The HTML element has a `js` class, and doesn't have a `no-js` class
- The map on <http://127.0.0.1:8002/about> displays fine (and looks the same as live)


Then without JavaScript:

- The HTML element has a `no-js` class, and no `js` class
- <http://127.0.0.1:8002/about> shows the "Where we are" row (and looks the same as live)