### PR TITLE
Remove YUI: Replace sectionTabs with new setupTabs

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -8,6 +8,7 @@
 
 // var core = {};
 
+
 /**
  * Show the cookie notification at the bottom of the page,
  * unless it has previously been dismissed
@@ -42,4 +43,37 @@ core.cookiePolicy = function() {
       createCookieNotification();
     }
   }
+
+/**
+ * Given a set of anchor triggers and a set of tab items,
+ * where the href of the anchors is equivalent to the ID of the target item:
+ * Add class 'hide' to all items except the one which is triggered,
+ * and add the class 'active' to the active anchor
+ *
+ * <a href="#one">anchor 1</a> <a href="#two active">anchor 2</a>
+ * <div id="one hide">item 1</div> <div id="two">item 2</div>
+ */
+core.setupTabs = function (menuAnchors, tabItems) {
+  menuAnchors.forEach(function(anchor) {
+    anchor.addEventListener(
+      'click',
+      function(menuAnchors, tabItems) {
+        return function(clickEvent) {
+          clickEvent.preventDefault();
+          anchor = clickEvent.target.closest('a');
+
+          // Get the ID for this item from the anchor's hash value
+          itemId = anchor.hash;
+
+          // Hide all items but display this one
+          tabItems.forEach(function(item) {item.classList.add('hide');});
+          document.querySelector(itemId).classList.remove('hide');
+
+          // Deactivate other items and activate this one
+          menuAnchors.forEach(function(anchor) {anchor.classList.remove('active');});
+          anchor.classList.add('active');
+        };
+      }(menuAnchors, tabItems)
+    );
+  });
 };

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -19,13 +19,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     });
   };
 
-  core.tabbedContent = function() {
-    Y.all('.tabbed-content .accordion-button').on('click', function(e){
-      e.preventDefault();
-      e.target.get('parentNode').toggleClass('open');
-    });
-  };
-
   core.sectionTabs = function () {
     if (Y.one('.tabbed-content')) {
       var p = Y.one('.tabbed-menu a.active'),
@@ -117,7 +110,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
 
   core.setupAccordion();
   core.sectionTabs();
-  core.tabbedContent();
   core.resizeListener();
 });
 

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -19,24 +19,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     });
   };
 
-  core.sectionTabs = function () {
-    if (Y.one('.tabbed-content')) {
-      var p = Y.one('.tabbed-menu a.active'),
-        s = p.get('href').split('#')[1],
-        w = (p.get('clientWidth') / 2) - 7,
-        x = (p.get('parentNode').getXY()[0] - p.get('parentNode').get('parentNode').getXY()[0]) + w;
-      Y.all('.tabbed-menu a').on('click', function (e) {
-        e.preventDefault();
-        Y.all('.tabbed-menu a').removeClass('active');
-        e.currentTarget.addClass('active');
-        Y.all('.tabbed-content').addClass('hide');
-        s = e.currentTarget.get('hash');
-        Y.one(s).removeClass('hide');
-        x = (e.currentTarget.get('parentNode').getXY()[0] - e.currentTarget.get('parentNode').get('parentNode').getXY()[0]) + w;
-      });
-    }
-  };
-
   core.resizeListener = function() {
     Y.on('windowresize', function(e) {
       core.redrawGlobal();
@@ -109,7 +91,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
   };
 
   core.setupAccordion();
-  core.sectionTabs();
   core.resizeListener();
 });
 

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -537,6 +537,12 @@ google.maps.event.addDomListener(window, 'load', initialize);
 {% block footer_extra %}
 <!-- script to get news, white papers and case studies -->
 <script type="text/javascript">
+  /* tabs */
+  core.setupTabs(
+    document.querySelectorAll('.tabbed-menu a'),
+    document.querySelectorAll('.tabbed-content')
+  );
+
   /* News */
   core.getInsightsFeed('https://insights.ubuntu.com/category/news/feed/', 4, '#news-feed', 'news');
 

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -94,7 +94,6 @@
       <img src="http://www.ubuntu.com/static/u/img/patterns/tabbed-nav-arrow.png" class="arrow" height="6" width="12" alt="" />
     </div><!-- /col -->
     <div id="jane-silber" class="tabbed-content panel nine-col last-col" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#jane-silber">Jane Silber</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">
@@ -113,7 +112,6 @@
       </div><!-- /col -->
     </div><!-- /person -->
     <div id="mark-shuttleworth" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#mark-shuttleworth">Mark Shuttleworth</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">
@@ -133,7 +131,6 @@
       </div>
     </div>
     <div id="anand-krishnan" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#anand-krishnan">Anand Krishnan</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">
@@ -152,7 +149,6 @@
       </div><!-- /col -->
     </div><!-- /person -->
     <div id="robbie-williamson" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#robbie-williamson">Robbie Williamson</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">
@@ -172,7 +168,6 @@
       </div>
     </div>
     <div id="chris-kenyon" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#chris-kenyon">Chris Kenyon</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">
@@ -191,7 +186,6 @@
       </div>
     </div>
     <div id="neil-french" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#neil-french">Neil French</a>
       <div class="nine-col">
         <div class="five-col">
           <div class="clearfix">

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -75,7 +75,6 @@
             <img src="http://www.ubuntu.com/static/u/img/patterns/tabbed-nav-arrow.png" class="arrow" height="6" width="12" alt="" />
         </div>
         <div id="design-and-user-experience" class="tabbed-content panel nine-col last-col">
-            <a class="accordion-button active slideless" href="#design-and-user-experience">Design and User Experience</a>
             <h3 class="title">Design and User Experience</h3>
             <div class="nine-col vertical-divider no-margin-bottom">
                 <div class="five-col">
@@ -109,7 +108,6 @@
             </div>
         </div>
         <div id="technical-and-engineering" class="tabbed-content panel nine-col last-col hide">
-            <a class="accordion-button slideless" href="#technical-and-engineering">Technical and Engineering</a>
             <h3 class="title">Technical and Engineering</h3>
             <div class="nine-col vertical-divider no-margin-bottom">
                 <div class="five-col">
@@ -143,7 +141,6 @@
             </div>
         </div>
         <div id="marketing-services" class="tabbed-content panel nine-col last-col hide">
-            <a class="accordion-button slideless" href="#marketing-services">Marketing and Business</a>
             <h3 class="title">Marketing and Business Development</h3>
             <div class="nine-col vertical-divider no-margin-bottom">
                 <div class="five-col">
@@ -177,7 +174,6 @@
             </div>
         </div>
         <div id="operations" class="tabbed-content panel nine-col last-col hide">
-            <a class="accordion-button slideless" href="#operations">Operations</a>
             <h3 class="title">Operations</h3>
             <div class="nine-col vertical-divider no-margin-bottom">
                 <div class="five-col">
@@ -211,7 +207,6 @@
             </div>
         </div>
         <div id="professional-services" class="tabbed-content panel nine-col last-col hide">
-            <a class="accordion-button slideless" href="#professional-services">Professional Services</a>
             <h3 class="title">Professional Services</h3>
             <div class="nine-col vertical-divider no-margin-bottom">
                 <div class="five-col">


### PR DESCRIPTION
**Please review and merge #105 first**

- Replace YUI with plain JavaScript
- Move to core.js
- Call the function from the bottom of each page that needs it

I've also removed the `tabbedContent` function and the `accordion-button` elements.
Since they weren't even visible on the existing pages, I'm guessing they're from a byegone era and so are no longer needed. **Please correct me if I'm wrong**.

QA
--

```
make run
```

Go to <http://www.canonical.com/careers> and <http://www.canonical.com/about> and check the "tabbed" sections still work as they do on live.