### PR TITLE
Remove SVG fallback

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -90,14 +90,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     }
   };
 
-  core.svgFallback = function() {
-    if (!Modernizr.svg || !Modernizr.backgroundsize) {
-      Y.all("img[src$='.svg']").each(function(node) {
-        node.setAttribute("src", node.getAttribute('src').toString().match(/.*\/(.+?)\./)[0]+'png');
-      });
-    }
-  };
-
   core.renderJSON = function (response, id) {
     if (id == undefined) {
         id = '#dynamic-logos';
@@ -220,7 +212,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
   core.setupHtmlClass();
   core.sectionTabs();
   core.tabbedContent();
-  core.svgFallback();
   core.resizeListener();
 });
 


### PR DESCRIPTION
scratch.js is only loaded inside an `[if gte IE 9]` conditional, and its really only <=IE8 which have SVG problems. Also, the SVG fallback script as it stands would be broken anyway, as it simply replaces `svg` with `png`, which doesn't work for the new assets server. I used [netrenderer](https://netrenderer.com/index.php) to confirm that no images show up properly on the live site.

Also, on ubuntu.com, IE8 now makes up 0.3% of our traffic (3.37% use IE, of which 8.24% is IE8). I'm gonna assume canonical.com is similar, so I don't think we should worry about it.

Therefore I think there's no point to the SVG fallback and it should be removed.

QA
---

Check you agree with me.

Run the site, click around check there are no JS errors.

For extra credits, check the whole site in IE8 against how it looks on live, and that it hasn't got worse.
