### PR TITLE
Remove YUI: Remove loadPartners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bzr-repo/
 django-error.log
 node_modules/
 .web_cache/
+cache.sqlite

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -9,3 +9,5 @@ django-static-root-finder==0.1
 django-asset-server-url==0.1
 feedparser==5.2.1
 requests==2.10.0
+requests-cache==0.4.12
+

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -85,32 +85,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     }
   };
 
-  core.renderJSON = function (response, id) {
-    if (id == undefined) {
-        id = '#dynamic-logos';
-    }
-    var JSON = response;
-    var numberPartners = JSON.length;
-    var numberToDisplay = numberPartners < 10 ? numberPartners : 10;
-
-    for (var i = 0; i < numberToDisplay; i++) {
-      Y.one(id).append(Y.Node.create('<li><img onload="this.style.opacity=\'1\';" src="'+JSON[i].logo+'" alt="'+JSON[i].name+'"></li>'));
-    }
-  };
-
-  core.loadPartners = function (params, elementID, feedName) {
-    if (typeof feedName === 'undefined') {
-      feedName = 'partners';
-    }
-
-    var partnersAPI = "http://partners.ubuntu.com/" + feedName + ".json";
-    var url = partnersAPI + params + "&callback={callback}";
-    var callback = function(response) {
-        return core.renderJSON(response, elementID);
-    }
-    Y.jsonp(url, callback);
-  };
-
   core.sectionTabs = function () {
     if (Y.one('.tabbed-content')) {
       var p = Y.one('.tabbed-menu a.active'),

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -36,7 +36,12 @@
 	<div class="inner-wrapper">
 		<div class="panel panel--alt twelve-col">
 			<h2 class="muted-heading">A selection of our cloud partners</h2>
-			<ul class="inline-logos no-bullets clear list-auto" id="cloud-logos"></ul>
+			{% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Cloud/server&featured=true" limit=10 as cloud_partners %}
+			<ul class="inline-logos no-bullets clear list-auto" id="cloud-logos">
+				{% for partner in cloud_partners %}
+				<li><img onload="this.style.opacity='1';" src="{{ partner.logo }}" alt="{{ partner.name }}"></li>
+				{% endfor %}
+			</ul>
 			<p class="align-center"><a href="http://partners.ubuntu.com/find-a-partner?technology=cloud/server" class="external">Browse all cloud partners</a></p>
 		</div>
 	</div>
@@ -67,7 +72,12 @@
 	<div class="inner-wrapper">
 		<div class="panel panel--alt twelve-col">
 			<h2 class="muted-heading">A selection of our client partners</h2>
-			<ul class="inline-logos no-bullets clear list-auto" id="client-logos"></ul>
+			{% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Technical Partner Programme" limit=10 as client_partners %}
+			<ul class="inline-logos no-bullets clear list-auto" id="client-logos">
+				{% for partner in client_partners %}
+				<li><img onload="this.style.opacity='1';" src="{{ partner.logo }}" alt="{{ partner.name }}"></li>
+				{% endfor %}
+			</ul>
 			<p class="align-center"><a href="http://partners.ubuntu.com/find-a-partner?technology=personal-computing/devices" class="external align-center">Browse all client partners</a></p>
 		</div>
 	</div>
@@ -127,16 +137,3 @@
 	</div>
 </div>
 {% endblock content %}
-
-{% block footer_extra %}
-
-<script>
-	YUI().use('event-base', function (Y) {
-		Y.on('domready', function () {
-			core.loadPartners('?technology__name=Cloud/server&featured=true', '#cloud-logos');
-			core.loadPartners('?programme__name=Technical Partner Programme', '#client-logos');
-		});
-	});
-</script>
-
-{% endblock %}

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -1,35 +1,67 @@
 import feedparser
 import logging
-import requests
-from cachecontrol import CacheControlAdapter
-from cachecontrol.caches import FileCache
-from cachecontrol.heuristics import ExpiresAfter
+import json
+from datetime import datetime
+from requests.exceptions import Timeout
+from requests_cache import CachedSession
+from time import mktime
+
 from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
+requests_timeout = getattr(settings, 'FEED_TIMEOUT', 60)
+expiry_seconds = getattr(settings, 'FEED_EXPIRY', 300)
+
+cached_request = CachedSession(
+    expire_after=expiry_seconds,
+)
 
 
-def get_feed(feed_url):
+def get_json_feed_content(url, offset=0, limit=None):
     """
-    Return feed parsed feed
+    Get the entries in a JSON feed
     """
-    requests_timeout = getattr(settings, 'FEED_TIMOUT', 1)
 
-    cache_adapter = CacheControlAdapter(
-        cache=FileCache('.web_cache'),
-        heuristic=ExpiresAfter(hours=1),
-    )
+    end = limit + offset if limit is not None else None
 
-    session = requests.Session()
-    session.mount('http://', cache_adapter)
-    session.mount('https://', cache_adapter)
+    try:
+        response = cached_request.get(url, timeout=requests_timeout)
+        content = json.loads(response.text)
+    except Timeout as timeout_error:
+        logger.warning(
+            'Attempt to get feed timed out after {}. Message: {}'.format(
+                requests_timeout,
+                str(timeout_error)
+            )
+        )
+        content = []  # Empty response
 
-    show_exceptions = getattr(settings, 'DEBUG', True)
+    return content[offset:end]
 
-    feed_request = session.get(
-        feed_url,
-        timeout=requests_timeout
-    )
 
-    return feedparser.parse(feed_request.text)
+def get_rss_feed_content(url, offset=0, limit=None):
+    """
+    Get the entries from an RSS feed
+    """
+
+    end = limit + offset if limit is not None else None
+
+    try:
+        response = cached_request.get(url, timeout=requests_timeout)
+        content = feedparser.parse(response.text).entries
+    except Timeout as timeout_error:
+        logger.warning(
+            'Attempt to get feed timed out after {}. Message: {}'.format(
+                requests_timeout,
+                str(timeout_error)
+            )
+        )
+        content = []  # Empty response
+
+    content = content[offset:end]
+    for item in content:
+        updated_time = mktime(item['updated_parsed'])
+        item['updated_datetime'] = datetime.fromtimestamp(updated_time)
+
+    return content

--- a/webapp/templatetags/feeds.py
+++ b/webapp/templatetags/feeds.py
@@ -1,9 +1,14 @@
 from django import template
-from webapp.lib import feeds
+from webapp.lib.feeds import get_json_feed_content, get_rss_feed_content
 
 register = template.Library()
 
 
 @register.simple_tag
-def get_feed(feed_url):
-    return feeds.get_feed(feed_url).entries
+def get_json_feed(feed_url, **kwargs):
+    return get_json_feed_content(feed_url, **kwargs)
+
+
+@register.simple_tag
+def get_rss_feed(feed_url, **kwargs):
+    return get_rss_feed_content(feed_url, **kwargs)


### PR DESCRIPTION
Port over the server-side feed solution from www.ubuntu.com,
and use that to replace uses of the `loadPartners` script.

QA
---

Run the site (`make run`). Browse to <http://127.0.0.1:8002/partners> and check both logo clouds load properly.

For extra credits, check these only contain partners that are in the correct filter in the partners website.