### PR TITLE
Remove YUI: Replace rssLoader with server-side feeds

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -46,45 +46,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
     });
   };
 
-  core.rssLoader = {
-    "outputFeed" : function(el, jobType) {
-      var element = document.getElementById(el);
-      if (jobType === undefined) {
-        jobType = '';
-      } else {
-        jobType = ' ' + jobType;
-      }
-      return function(result){
-        if (!result.error){
-          var output = '';
-          var thefeeds = result.feed.entries;
-          var spinner = document.getElementById('spinner');
-          if(spinner !== null){
-            spinner.style.display = 'none';
-          }
-          if(element.className.indexOf('with-total') != -1){
-            output += '<li>We currently have '+thefeeds.length+jobType+' vacancies';
-          }
-          for (var i = 0; i < thefeeds.length; i++){
-            output += '<li><a href="{0}">{1} &rsaquo;</a></li>'.format(thefeeds[i].link, thefeeds[i].title);
-          }
-          element.innerHTML = element.innerHTML + output;
-          return output;
-        }
-      }
-    },
-
-    "getFeed" : function(url, numItems, el, jobType){
-      var feedpointer = new google.feeds.Feed(url); //Google Feed API method
-      if(numItems != null){
-        feedpointer.setNumEntries(numItems); //Google Feed API method
-      }else{
-        feedpointer.setNumEntries(250); //Google Feed API method
-      }
-      feedpointer.load(this.outputFeed(el, jobType)); //Google Feed API method
-    }
-  };
-
   core.sectionTabs = function () {
     if (Y.one('.tabbed-content')) {
       var p = Y.one('.tabbed-menu a.active'),
@@ -180,37 +141,6 @@ YUI().use('node', 'cookie', 'event-resize', 'event', 'jsonp', 'json-parse', func
   core.tabbedContent();
   core.resizeListener();
 });
-
-core.rssLoader = function(feedurl, jobType, htmlelement, joblimit) {
-  $.getFeed({
-    url: feedurl,
-    success: function(feed) {
-      var html = '';
-      /* correct grammar for 0 and 1 on total list item */
-      if (feed.items.length === 0) {
-        html += '<li class="total">Sorry, we currently have no ' + jobType + ' vacancies';
-      } else if (feed.items.length === 1) {
-        html += '<li class="total">We currently have ' + feed.items.length + ' ' + jobType + ' vacancy';
-      } else {
-        html += '<li class="total">We currently have ' + feed.items.length + ' ' + jobType + ' vacancies';
-      }
-
-      /* set a default limit for number of jobs returned */
-      if (joblimit == undefined) {
-        joblimit = 5;
-      }
-
-      for(var i = 0; i < feed.items.length && i < joblimit; i++) {
-        var item = feed.items[i];
-        html += "<li><a href='" + item.link + "'>" + item.title + "&nbsp;&rsaquo;</a></li>";
-      }
-
-      /* hide the gif spinner */
-      $('.spinner').hide();
-      $(htmlelement).append(html);
-    }
-  })
-};
 
 core.getInsightsFeed = function(url, maxItems, htmlID, type) {
   $.getFeed({

--- a/templates/_includes/vacancies.html
+++ b/templates/_includes/vacancies.html
@@ -1,0 +1,17 @@
+<li class="total">
+  {% if vacancies %}
+    We currently have {{ vacancies | length }} {{ job_type }} vacancies
+  {% else %}
+    Sorry, we currently have no {{ job_type }} vacancies
+  {% endif %}
+</li>
+
+{% if limit %}
+  {% for job in vacancies|slice:limit %}
+    <li><a href="{{ job.link }}">{{ job.title }}&nbsp;&rsaquo;</a></li>
+  {% endfor %}
+{% else %}
+  {% for job in vacancies %}
+    <li><a href="{{ job.link }}">{{ job.title }}&nbsp;&rsaquo;</a></li>
+  {% endfor %}
+{% endif %}

--- a/templates/careers/all-design-and-user-experience-vacancies.html
+++ b/templates/careers/all-design-and-user-experience-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=610" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=610", 20, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/all-marketing-and-business-development-vacancies.html
+++ b/templates/careers/all-marketing-and-business-development-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=11588%2C6158%2C616" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=11588%2C6158%2C616", null, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/all-operations-vacancies.html
+++ b/templates/careers/all-operations-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=615%2C613%2C614" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=615%2C613%2C614", null, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/all-professional-services-vacancies.html
+++ b/templates/careers/all-professional-services-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&keywords=professional" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&keywords=professional", null, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/all-technical-and-engineering-vacancies.html
+++ b/templates/careers/all-technical-and-engineering-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=617" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=617", null, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/all-vacancies.html
+++ b/templates/careers/all-vacancies.html
@@ -18,13 +18,10 @@
 			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -45,11 +42,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2", null, "job-feed");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/cloud-vacancies.html
+++ b/templates/careers/cloud-vacancies.html
@@ -13,7 +13,7 @@
 	<div class="inner-wrapper">
 		<div class="six-col">
 			<h1>All cloud vacancies</h1>
-			<p>No other operating system can compete with Ubuntu’s long history of integration with the open cloud – and we are always working to widen that lead. Our cloud teams work on MaaS, our provisioning software, and Juju, our service orchestration tool – not to mention OpenStack itself. 
+			<p>No other operating system can compete with Ubuntu’s long history of integration with the open cloud – and we are always working to widen that lead. Our cloud teams work on MaaS, our provisioning software, and Juju, our service orchestration tool – not to mention OpenStack itself.
 In short, we’re all about cloud. Are you?</p>
 			<p><a href="http://www.ubuntu.com/cloud" class="external">More about our cloud products</a></p>
 		</div>
@@ -46,13 +46,10 @@ In short, we’re all about cloud. Are you?</p>
 <div class="strip row">
 	<div class="inner-wrapper">
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1371" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -73,11 +70,4 @@ In short, we’re all about cloud. Are you?</p>
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1371", 20, "job-feed", 'cloud');
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/go-vacancies.html
+++ b/templates/careers/go-vacancies.html
@@ -47,13 +47,10 @@
 <div class="strip row">
 	<div class="inner-wrapper">
 		<div class="eight-col">
-			<div class="spinner" id="spinner">
-				<div class="bounce1"></div>
-				<div class="bounce2"></div>
-				<div class="bounce3"></div>
-			</div>
-			<noscript><p>Please enable javascript to display this feed. Otherwise you can view <a href="https://tbe.taleo.net/CH03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">all vacancies here</a>.</p></noscript>
-			<ul class="vacancies list with-total" id="job-feed"></ul>
+			<ul class="vacancies list with-total" id="job-feed">
+				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1372" as vacancies %}
+				{% include "_includes/vacancies.html" with vacancies=vacancies %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -74,11 +71,4 @@
 	    </div>
 	</div>
 </div><!-- /.row -->
-
-<script type="text/javascript">
-	window.onload = function() {
-		core.rssLoader.getFeed("https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1372", 20, "job-feed", "Go");
-	}
-</script>
-
 {% endblock content %}

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -82,8 +82,12 @@
                     <p>There are few organisations in the world where interface designers, graphic designers and user experience professionals come together on such a fascinating array of projects. From our office in London, this team creates the look, feel and interaction models for technologies as diverse as the Juju service orchestration tool and the Ubuntu Touch mobile interface. </p>
                 </div>
                 <div class="four-col last-col">
-                    <h4>Latest vacancies &mdash; <a href="/careers/all-design-and-user-experience-vacancies">View all&nbsp;&rsaquo;</a></h4>
-                    <ul class="vacancies" id="design-job-feed"></ul>
+                  <h4>Latest vacancies &mdash; <a href="/careers/all-design-and-user-experience-vacancies">View all&nbsp;&rsaquo;</a></h4>
+
+                  <ul class="vacancies" id="design-job-feed">
+                    {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=610" as design_vacancies %}
+                    {% include "_includes/vacancies.html" with vacancies=design_vacancies job_type="design" limit="5" %}
+                  </ul>
                 </div>
             </div>
             <div class="nine-col profile" itemscope itemtype="http://schema.org/Person">
@@ -113,7 +117,11 @@
                 </div>
                 <div class="four-col last-col no-margin-bottom">
                     <h4>Latest vacancies &mdash;<a href="/careers/all-technical-and-engineering-vacancies">View all&nbsp;&rsaquo;</a></h4>
-                    <ul class="vacancies" id="technical-job-feed"></ul>
+
+                    <ul class="vacancies" id="technical-job-feed">
+                      {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=617" as technical_vacancies %}
+                      {% include "_includes/vacancies.html" with vacancies=technical_vacancies job_type="technical and engineering" limit="5" %}
+                    </ul>
                 </div>
             </div>
             <div class="nine-col profile" itemscope itemtype="http://schema.org/Person">
@@ -143,7 +151,11 @@
                 </div>
                 <div class="four-col last-col">
                     <h4>Latest vacancies &mdash; <a href="/careers/all-marketing-and-business-development-vacancies">View all&nbsp;&rsaquo;</a></h4>
-                    <ul class="vacancies" id="marketing-job-feed"></ul>
+
+                    <ul class="vacancies" id="marketing-job-feed">
+                      {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=11588%2C6158%2C616" as marketing_vacancies %}
+                      {% include "_includes/vacancies.html" with vacancies=marketing_vacancies job_type="marketing and business development" limit="5" %}
+                    </ul>
                 </div>
             </div>
             <div class="nine-col profile" itemscope itemtype="http://schema.org/Person">
@@ -173,7 +185,11 @@
                 </div>
                 <div class="four-col last-col">
                     <h4>Latest vacancies &mdash; <a href="/careers/all-operations-vacancies">View all&nbsp;&rsaquo;</a></h4>
-                    <ul class="vacancies" id="operations-job-feed"></ul>
+
+                    <ul class="vacancies" id="operations-job-feed">
+                      {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=615%2C613%2C614" as operations_vacancies %}
+                      {% include "_includes/vacancies.html" with vacancies=operations_vacancies job_type="operations" limit="5" %}
+                    </ul>
                 </div>
             </div>
             <div class="nine-col profile" itemscope itemtype="http://schema.org/Person">
@@ -203,7 +219,11 @@
                 </div>
                 <div class="four-col last-col">
                     <h4>Latest vacancies &mdash; <a href="/careers/all-professional-services-vacancies">View all&nbsp;&rsaquo;</a></h4>
-                    <ul class="vacancies" id="professional-job-feed"></ul>
+
+                    <ul class="vacancies" id="professional-job-feed">
+                      {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&keywords=professional" as professional_vacancies %}
+                      {% include "_includes/vacancies.html" with vacancies=professional_vacancies job_type="professional services" limit="5" %}
+                    </ul>
                 </div>
             </div>
             <div class="nine-col profile" itemscope itemtype="http://schema.org/Person">
@@ -249,15 +269,3 @@
 </div><!-- /.row -->
 
 {% endblock content %}
-
-{% block footer_extra %}
-<script type="text/javascript">
-  YUI().use(function(Y) {
-    core.rssLoader("http://www.stmgrts.org.uk/taleo/taleo_design-job-feed.xml", "design", "#design-job-feed");
-    core.rssLoader("http://www.stmgrts.org.uk/taleo/taleo_technical-job-feed.xml",  "technical and engineering", "#technical-job-feed");
-    core.rssLoader("http://www.stmgrts.org.uk/taleo/taleo_marketing-job-feed.xml", "marketing and business development", "#marketing-job-feed");
-    core.rssLoader("http://www.stmgrts.org.uk/taleo/taleo_operations-job-feed.xml", "operations", "#operations-job-feed");
-    core.rssLoader("http://www.stmgrts.org.uk/taleo/taleo_professional-job-feed.xml", "professional services", "#professional-job-feed");
-    });
-</script>
-{% endblock %}


### PR DESCRIPTION
Use `get_rss_feed` instead of rssLoader.

Also, stop using stmgrts.org.uk feed mirror, just use feeds direct from taleo.

QA
--

Run site (`make run`).

Go to <http://127.0.0.1:8002/careers/>, and all <http://127.0.0.1:8002/careers/*-vacancies> pages, and check all feeds load properly and show correct jobs.