### PR TITLE
Update all taleo links

### DIFF
--- a/templates/careers/all-design-and-user-experience-vacancies.html
+++ b/templates/careers/all-design-and-user-experience-vacancies.html
@@ -6,36 +6,22 @@
 
 {% block content %}
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<h1>All Design and User Experience vacancies</h1>
-		</div>
-		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
-		</div>
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=610" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <h1>All Design and User Experience vacancies</h1>
+        </div>
+        <div class="eight-col">
+            <p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">search jobs</a>.</p>
+        </div>
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/all-design-and-user-experience-vacancies.html
+++ b/templates/careers/all-design-and-user-experience-vacancies.html
@@ -15,7 +15,7 @@
         </div>
         <div class="eight-col">
             <ul class="vacancies list with-total" id="job-feed">
-                {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as vacancies %}
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as vacancies %}
                 {% include "_includes/vacancies.html" with vacancies=vacancies %}
             </ul>
         </div>

--- a/templates/careers/all-marketing-and-business-development-vacancies.html
+++ b/templates/careers/all-marketing-and-business-development-vacancies.html
@@ -11,31 +11,17 @@
 			<h1>All Marketing and Business Development vacancies</h1>
 		</div>
 		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
+			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">search jobs</a>.</p>
 		</div>
 		<div class="eight-col">
 			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=11588%2C6158%2C616" as vacancies %}
+				{% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as vacancies %}
 				{% include "_includes/vacancies.html" with vacancies=vacancies %}
 			</ul>
 		</div>
 	</div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/all-marketing-and-business-development-vacancies.html
+++ b/templates/careers/all-marketing-and-business-development-vacancies.html
@@ -15,7 +15,7 @@
 		</div>
 		<div class="eight-col">
 			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as vacancies %}
+				{% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as vacancies %}
 				{% include "_includes/vacancies.html" with vacancies=vacancies %}
 			</ul>
 		</div>

--- a/templates/careers/all-operations-vacancies.html
+++ b/templates/careers/all-operations-vacancies.html
@@ -6,36 +6,22 @@
 
 {% block content %}
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<h1>All Operations vacancies</h1>
-		</div>
-		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
-		</div>
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=615%2C613%2C614" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <h1>All Operations vacancies</h1>
+        </div>
+        <div class="eight-col">
+            <p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">search jobs</a>.</p>
+        </div>
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=615,613,614" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/all-professional-services-vacancies.html
+++ b/templates/careers/all-professional-services-vacancies.html
@@ -6,36 +6,22 @@
 
 {% block content %}
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="six-col">
-			<h1>All Professional Services vacancies</h1>
-		</div>
-		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
-		</div>
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&keywords=professional" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="six-col">
+            <h1>All Professional Services vacancies</h1>
+        </div>
+        <div class="eight-col">
+            <p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">search jobs</a>.</p>
+        </div>
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&keywords=professional" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/all-technical-and-engineering-vacancies.html
+++ b/templates/careers/all-technical-and-engineering-vacancies.html
@@ -6,36 +6,22 @@
 
 {% block content %}
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<h1>All Technical and Engineering vacancies</h1>
-		</div>
-		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
-		</div>
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=617" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <h1>All Technical and Engineering vacancies</h1>
+        </div>
+        <div class="eight-col">
+            <p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">search jobs</a>.</p>
+        </div>
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=617" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/all-vacancies.html
+++ b/templates/careers/all-vacancies.html
@@ -6,36 +6,36 @@
 
 {% block content %}
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="six-col">
-			<h1>All current vacancies</h1>
-		</div>
-		<div class="eight-col">
-			<p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
-		</div>
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="six-col">
+            <h1>All current vacancies</h1>
+        </div>
+        <div class="eight-col">
+            <p class="intro">If you are interested in a role in a specific department or location, you can <a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">search jobs</a>.</p>
+        </div>
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&_rss_version=2&cws=1" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
 <div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers">Working at Canonical&nbsp;&rsaquo;</a></h3>
-	        <p>Whether you're a designer, a technologist or a business professional, Canonical is an incredible place to work.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="http://design.canonical.com/" class="external">Ubuntu design blog</a></h3>
-	        <p>On the Ubuntu design blog, the Canonical design team shares its process, thoughts and inspiration.</p>
-	    </div>
-	</div>
+    <div class="inner-wrapper vertical-divider">
+        <div class="featured six-col">
+            <h3><a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search roles &rsaquo;</a></h3>
+            <p>Search for vacant positions by location, department or by using keywords.</p>
+        </div>
+        <div class="three-col">
+            <h3><a href="/careers">Working at Canonical&nbsp;&rsaquo;</a></h3>
+            <p>Whether you're a designer, a technologist or a business professional, Canonical is an incredible place to work.</p>
+        </div>
+        <div class="three-col last-col">
+            <h3><a href="http://design.canonical.com/" class="external">Ubuntu design blog</a></h3>
+            <p>On the Ubuntu design blog, the Canonical design team shares its process, thoughts and inspiration.</p>
+        </div>
+    </div>
 </div><!-- /.row -->
 {% endblock content %}

--- a/templates/careers/all-vacancies.html
+++ b/templates/careers/all-vacancies.html
@@ -15,7 +15,7 @@
         </div>
         <div class="eight-col">
             <ul class="vacancies list with-total" id="job-feed">
-                {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&_rss_version=2&cws=1" as vacancies %}
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&_rss_version=2&cws=1" as vacancies %}
                 {% include "_includes/vacancies.html" with vacancies=vacancies %}
             </ul>
         </div>

--- a/templates/careers/cloud-vacancies.html
+++ b/templates/careers/cloud-vacancies.html
@@ -6,64 +6,50 @@
 
 {% block content %}
 <div class="row row-hero">
-	<div class="inner-wrapper">
-		<div class="six-col">
-			<h1>All cloud vacancies</h1>
-			<p>No other operating system can compete with Ubuntu’s long history of integration with the open cloud – and we are always working to widen that lead. Our cloud teams work on MaaS, our provisioning software, and Juju, our service orchestration tool – not to mention OpenStack itself.
+    <div class="inner-wrapper">
+        <div class="six-col">
+            <h1>All cloud vacancies</h1>
+            <p>No other operating system can compete with Ubuntu’s long history of integration with the open cloud – and we are always working to widen that lead. Our cloud teams work on MaaS, our provisioning software, and Juju, our service orchestration tool – not to mention OpenStack itself.
 In short, we’re all about cloud. Are you?</p>
-			<p><a href="http://www.ubuntu.com/cloud" class="external">More about our cloud products</a></p>
-		</div>
-		<div class="six-col last-col text-center">
-			<img src="{{ ASSET_SERVER_URL }}fd5d58d0-image-cloudvacancies.svg" width="350" alt="Cloud">
-		</div>
-	</div>
+            <p><a href="http://www.ubuntu.com/cloud" class="external">More about our cloud products</a></p>
+        </div>
+        <div class="six-col last-col text-center">
+            <img src="{{ ASSET_SERVER_URL }}fd5d58d0-image-cloudvacancies.svg" width="350" alt="Cloud">
+        </div>
+    </div>
 </div>
 
 <div class="row strip strip-light">
-	<div class="inner-wrapper">
-		<div class="four-col profile">
-			<img class="portrait" itemprop="image" src="{{ ASSET_SERVER_URL }}4afcf1ef-image-jeff.png" alt="Jeff">
-			<ul class="personal-info">
-				<li class="name" itemprop="name">Jeff</li>
-				<li class="role" itemprop="jobTitle">Server Certification Engineer</li>
-				<li class="location">USA</li>
-			</ul>
-		</div>
-		<div class="six-col last-col">
-			<blockquote class="pull-quote">
-				<p><span>“</span>It’s about the awesome people I get to work with daily and the opportunity to directly affect the direction of Ubuntu.<span>”</span></p>
-			</blockquote>
-			<p class="question">What is your greatest accomplishment at Canonical?</p>
-			<p>Building the Server Certification Programme up from just a concept to a full, self&dash;sustaining programme.  Also designing most of the server test suite and applying that to the cloud.</p>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="four-col profile">
+            <img class="portrait" itemprop="image" src="{{ ASSET_SERVER_URL }}4afcf1ef-image-jeff.png" alt="Jeff">
+            <ul class="personal-info">
+                <li class="name" itemprop="name">Jeff</li>
+                <li class="role" itemprop="jobTitle">Server Certification Engineer</li>
+                <li class="location">USA</li>
+            </ul>
+        </div>
+        <div class="six-col last-col">
+            <blockquote class="pull-quote">
+                <p><span>“</span>It’s about the awesome people I get to work with daily and the opportunity to directly affect the direction of Ubuntu.<span>”</span></p>
+            </blockquote>
+            <p class="question">What is your greatest accomplishment at Canonical?</p>
+            <p>Building the Server Certification Programme up from just a concept to a full, self&dash;sustaining programme.  Also designing most of the server test suite and applying that to the cloud.</p>
+        </div>
+    </div>
 </div>
 
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1371" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_1123=1371" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/go-vacancies.html
+++ b/templates/careers/go-vacancies.html
@@ -6,65 +6,51 @@
 
 {% block content %}
 <div class="row row-hero">
-	<div class="inner-wrapper">
-		<div class="six-col">
-			<h1>All Go vacancies</h1>
-			<p>The Juju Engineering Team is responsible for turning our service orchestration strategy into reality &mdash; and we need more great Go engineers. These roles involve more than just coding, however. We need people who can solve complex problems, collaborate with a global community and work directly with our biggest clients. </p>
-			<p><a href="https://demo.jujucharms.com" class="external">Try our GUI-based demo</a></p>
-			<p><a href="https://jujucharms.com/about" class="external">Learn more about Juju</a></p>
-			<p><a href="https://code.launchpad.net/juju-core" class="external">Check out the code</a></p>
-		</div>
-		<div class="push-one five-col last-col">
-			<img src="{{ ASSET_SERVER_URL }}e930b8ae-image-govacancies.svg" alt="Golang Gopher">
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="six-col">
+            <h1>All Go vacancies</h1>
+            <p>The Juju Engineering Team is responsible for turning our service orchestration strategy into reality &mdash; and we need more great Go engineers. These roles involve more than just coding, however. We need people who can solve complex problems, collaborate with a global community and work directly with our biggest clients. </p>
+            <p><a href="https://demo.jujucharms.com" class="external">Try our GUI-based demo</a></p>
+            <p><a href="https://jujucharms.com/about" class="external">Learn more about Juju</a></p>
+            <p><a href="https://code.launchpad.net/juju-core" class="external">Check out the code</a></p>
+        </div>
+        <div class="push-one five-col last-col">
+            <img src="{{ ASSET_SERVER_URL }}e930b8ae-image-govacancies.svg" alt="Golang Gopher">
+        </div>
+    </div>
 </div>
 
 <div class="row strip strip-light">
-	<div class="inner-wrapper">
-		<div class="four-col profile">
-			<img class="portrait" itemprop="image" src="{{ ASSET_SERVER_URL }}87807b55-image-dimiter.png" alt="Dimiter">
-			<ul class="personal-info">
-				<li class="name" itemprop="name">Dimiter</li>
-				<li class="role" itemprop="jobTitle">Software Engineer &dash; Juju Core</li>
-				<li class="location">Bulgaria</li>
-			</ul>
-		</div>
-		<div class="six-col last-col">
-			<blockquote class="pull-quote">
-				<p><span>“</span>One of the best things about Gophercon was hearing people ask about Juju. It must be the biggest Go&dash;based product outside Google.<span>”</span></p>
-			</blockquote>
-			<p class="question">What is your greatest accomplishment at Canonical?</p>
-			<p>Definitely my work on Juju &mdash; it&rsquo;s the reason I learned Go. I worked on the library that talks to the OpenStack API, Goose (Go OpenStack Exchange), to help implement OpenStack as a provider in Juju.</p>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="four-col profile">
+            <img class="portrait" itemprop="image" src="{{ ASSET_SERVER_URL }}87807b55-image-dimiter.png" alt="Dimiter">
+            <ul class="personal-info">
+                <li class="name" itemprop="name">Dimiter</li>
+                <li class="role" itemprop="jobTitle">Software Engineer &dash; Juju Core</li>
+                <li class="location">Bulgaria</li>
+            </ul>
+        </div>
+        <div class="six-col last-col">
+            <blockquote class="pull-quote">
+                <p><span>“</span>One of the best things about Gophercon was hearing people ask about Juju. It must be the biggest Go&dash;based product outside Google.<span>”</span></p>
+            </blockquote>
+            <p class="question">What is your greatest accomplishment at Canonical?</p>
+            <p>Definitely my work on Juju &mdash; it&rsquo;s the reason I learned Go. I worked on the library that talks to the OpenStack API, Goose (Go OpenStack Exchange), to help implement OpenStack as a provider in Juju.</p>
+        </div>
+    </div>
 </div>
 
 <div class="strip row">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<ul class="vacancies list with-total" id="job-feed">
-				{% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_1123=1372" as vacancies %}
-				{% include "_includes/vacancies.html" with vacancies=vacancies %}
-			</ul>
-		</div>
-	</div>
+    <div class="inner-wrapper">
+        <div class="eight-col">
+            <ul class="vacancies list with-total" id="job-feed">
+                {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_1123=1372" as vacancies %}
+                {% include "_includes/vacancies.html" with vacancies=vacancies %}
+            </ul>
+        </div>
+    </div>
 </div>
 
-<div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-	    <div class="featured six-col">
-	        <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
-	        <p>Search for vacant positions by location, department or by using keywords.</p>
-	    </div>
-	    <div class="three-col">
-	        <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
-	        <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
-	    </div>
-	    <div class="three-col last-col">
-	        <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
-	        <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
-	    </div>
-	</div>
-</div><!-- /.row -->
+{% include "careers/vacancies_contextual_footer.html" %}
+
 {% endblock content %}

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -70,7 +70,7 @@
             </div>
             <p class="priority-0">
                 <a class="see-all" href="/careers/all-vacancies">See all vacancies &rsaquo;</a>
-                <a class="search" href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search for jobs &rsaquo;</a>
+                <a class="search" href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search for jobs &rsaquo;</a>
             </p>
             <img src="{{ ASSET_SERVER_URL }}1000a177-tabbed-nav-arrow.png" class="arrow" height="6" width="12" alt="" />
         </div>
@@ -86,7 +86,7 @@
                       <h4>Latest vacancies &mdash; <a href="/careers/all-design-and-user-experience-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                       <ul class="vacancies" id="design-job-feed">
-                        {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=610" as design_vacancies %}
+                        {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as design_vacancies %}
                         {% include "_includes/vacancies.html" with vacancies=design_vacancies job_type="design" limit="5" %}
                       </ul>
                     </div>
@@ -122,7 +122,7 @@
                         <h4>Latest vacancies &mdash;<a href="/careers/all-technical-and-engineering-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="technical-job-feed">
-                          {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=617" as technical_vacancies %}
+                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=617" as technical_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=technical_vacancies job_type="technical and engineering" limit="5" %}
                         </ul>
                     </div>
@@ -158,7 +158,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-marketing-and-business-development-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="marketing-job-feed">
-                          {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=11588%2C6158%2C616" as marketing_vacancies %}
+                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as marketing_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=marketing_vacancies job_type="marketing and business development" limit="5" %}
                         </ul>
                     </div>
@@ -194,7 +194,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-operations-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="operations-job-feed">
-                          {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&CUSTOM_755=615%2C613%2C614" as operations_vacancies %}
+                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=615,613,614" as operations_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=operations_vacancies job_type="operations" limit="5" %}
                         </ul>
                     </div>
@@ -230,7 +230,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-professional-services-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="professional-job-feed">
-                          {% get_rss_feed "https://ch.tbe.taleo.net/CH03/ats/servlet/Rss?org=CANONICAL&cws=1&WebPage=SRCHR&WebVersion=0&_rss_version=2&keywords=professional" as professional_vacancies %}
+                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&keywords=professional" as professional_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=professional_vacancies job_type="professional services" limit="5" %}
                         </ul>
                     </div>
@@ -255,8 +255,8 @@
             </div>
         </div>
         <div class="small-menu">
-            <a class="see-all" href="https://tbe.taleo.net/NA3/ats/careers/searchResults.jsp?org=CANONICAL&amp;cws=1&amp;act=sort&amp;sortColumn=2&amp;sortColumn=0">See all vacancies &rsaquo;</a>
-            <a class="search" href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search for jobs &rsaquo;</a>
+            <a class="see-all" href="https://ldd.tbe.taleo.net/ldd03/ats/careers/searchResults.jsp?org=CANONICAL&cws=1&act=sort&sortColumn=2&sortColumn=0">See all vacancies &rsaquo;</a>
+            <a class="search" href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search for jobs &rsaquo;</a>
         </div>
     </div>
 </div>
@@ -264,7 +264,7 @@
 <div class="row row-contextual-footer">
     <div class="inner-wrapper vertical-divider">
         <div class="featured six-col">
-            <h3><a href="https://tbe.taleo.net/CH03/ats/careers/jobSearch.jsp?org=CANONICAL&amp;cws=1&amp;rid=86">Search roles &rsaquo;</a></h3>
+            <h3><a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
             <p>For anyone interested in open source software and Ubuntu in particular, Canonical is an incredible place to work.</p>
         </div>
         <div class="three-col">

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -86,7 +86,7 @@
                       <h4>Latest vacancies &mdash; <a href="/careers/all-design-and-user-experience-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                       <ul class="vacancies" id="design-job-feed">
-                        {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as design_vacancies %}
+                        {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=610" as design_vacancies %}
                         {% include "_includes/vacancies.html" with vacancies=design_vacancies job_type="design" limit="5" %}
                       </ul>
                     </div>
@@ -122,7 +122,7 @@
                         <h4>Latest vacancies &mdash;<a href="/careers/all-technical-and-engineering-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="technical-job-feed">
-                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=617" as technical_vacancies %}
+                          {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=617" as technical_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=technical_vacancies job_type="technical and engineering" limit="5" %}
                         </ul>
                     </div>
@@ -158,7 +158,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-marketing-and-business-development-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="marketing-job-feed">
-                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as marketing_vacancies %}
+                          {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=11588,6158,616" as marketing_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=marketing_vacancies job_type="marketing and business development" limit="5" %}
                         </ul>
                     </div>
@@ -194,7 +194,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-operations-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="operations-job-feed">
-                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=615,613,614" as operations_vacancies %}
+                          {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&CUSTOM_755=615,613,614" as operations_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=operations_vacancies job_type="operations" limit="5" %}
                         </ul>
                     </div>
@@ -230,7 +230,7 @@
                         <h4>Latest vacancies &mdash; <a href="/careers/all-professional-services-vacancies">View all&nbsp;&rsaquo;</a></h4>
 
                         <ul class="vacancies" id="professional-job-feed">
-                          {% get_rss_feed "https://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&keywords=professional" as professional_vacancies %}
+                          {% get_rss_feed "http://ldd.tbe.taleo.net/ldd03/ats/servlet/Rss?org=CANONICAL&cws=1&_rss_version=2&keywords=professional" as professional_vacancies %}
                           {% include "_includes/vacancies.html" with vacancies=professional_vacancies job_type="professional services" limit="5" %}
                         </ul>
                     </div>

--- a/templates/careers/vacancies_contextual_footer.html
+++ b/templates/careers/vacancies_contextual_footer.html
@@ -1,0 +1,16 @@
+<div class="row row-contextual-footer">
+    <div class="inner-wrapper vertical-divider">
+        <div class="featured six-col">
+            <h3><a href="https://ldd.tbe.taleo.net/ldd03/ats/careers/jobSearch.jsp?org=CANONICAL&cws=1&rid=86">Search roles &rsaquo;</a></h3>
+            <p>Search for vacant positions by location, department or by using keywords.</p>
+        </div>
+        <div class="three-col">
+            <h3><a href="/careers/all-vacancies">View all roles &rsaquo;</a></h3>
+            <p>We're always on the lookout for people with experience in open source software, the cloud or mobile devices.</p>
+        </div>
+        <div class="three-col last-col">
+            <h3><a href="/careers">Working at Canonical &rsaquo;</a></h3>
+            <p>Whether you&rsquo;re a designer, a technologist or a business professional, Canonical is an incredible place to work. </p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Most taleo links currently follow 2 redirects and eventually end up on ldd.tbe.taleo.net.

This is inefficient, but more importantly it makes it much more complicated to allow these requests through the firewall.

So I'm updating all these to point to their eventual targets.

QA
---

Go through each page on the `/careers` section and check that all feeds look correct and that all links to search for jobs still work.