### PR TITLE
Add proxy SSL detection

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -19,6 +19,9 @@ INSTALLED_APPS = ['django_versioned_static_url']
 
 ALLOWED_HOSTS = ['*']
 
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 MIDDLEWARE_CLASSES = []
 
 ROOT_URLCONF = 'webapp.urls'


### PR DESCRIPTION
Detect if the site is running https by checking the 'HTTP_X_FORWARDED_PROTO' header. This is set in our mojo deploy settings.

This setting is currently working correctly with assets manager