### PR TITLE
update the error pages' links to point to github

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -15,9 +15,8 @@
 		<div class="six-col last-col">
 			<h1>404: Page not found</h1>
 			<p class="intro">Sorry, we can't find the page you're looking for.</p>
-			<p>If you think this is an error on our site, please <a href="https://bugs.launchpad.net/canonical-website-content/+filebug">file a bug</a>.</p>
+			<p>If you think this is an error on our site, please <a href="https://github.com/ubuntudesign/www.canonical.com/issues/new" class="external">file a bug</a>.</p>
 		</div>
 	</div>
 </div>
 {% endblock %}
-

--- a/templates/500.html
+++ b/templates/500.html
@@ -82,7 +82,7 @@
 		<div class="six-col last-col">
 			<h1>500: Server error</h1>
 			<p class="intro">Something went wrong on our end.</p>
-			<p>If you have the time, please help us out by <a href="https://bugs.launchpad.net/canonical-website-content/+filebug">filing a bug</a>.</p>
+			<p>If you have the time, please help us out by <a href="https://github.com/ubuntudesign/www.canonical.com/issues/new" class="external">filing a bug</a>.</p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
### Done
Updated the URLs to report bugs on the 404 and 500 error pages.

### QA
View /404 and /500 and see the updated links.
Also note that they are now, correctly, external links.

Fixes #121 